### PR TITLE
Use statically allocated MAC address for all ifs.

### DIFF
--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -605,7 +605,7 @@ class LibvirtGenericVIFDriver(LibvirtBaseVIFDriver):
         super(LibvirtGenericVIFDriver,
               self).plug(instance, vif)
         dev = self.get_vif_devname(vif)
-        linux_net.create_tap_dev(dev)
+        linux_net.create_tap_dev(dev, mac_address='00:61:fe:ed:ca:fe')
 
     def plug(self, instance, vif):
         vif_type = vif['type']


### PR DESCRIPTION
This is one of three pull requests adding this function to the Calico branch of Nova. The other two are #2 and #3.

This change gives all tap devices created by Nova the same MAC address. This is necessary to ensure that VM migration correctly works without poisoning VM ARP caches. This change is temporary: we hope that the [Nova VIF plug_script](https://etherpad.openstack.org/p/nova_vif_plug_script_spec) mechanism will give us the flexibility to remove this patch.

The MAC address chosen is believed to lie in unallocated MAC space, which should reduce the risk of collision.
